### PR TITLE
Added the possibility to execute docker commands on multiple images

### DIFF
--- a/lib/commandProxy.js
+++ b/lib/commandProxy.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var _ = require('lodash');
+var availableColors = ['red','green', 'yellow', 'blue', 'magenta', 'cyan', 'white', 'gray', 'grey'];
 var runCommandOnContainer = require('./commands/runDockerCommand');
 
 function yargsToArgs(yargs) {
@@ -23,13 +24,20 @@ function yargsToArgs(yargs) {
 }
 
 module.exports = function(psTable, args) {
-  if (args.image.indexOf(':') < 0) {
-    args.image += ':latest';
-  }
+  var images = args.image.split(',');
 
-  var filteredTable = _.filter(psTable, {IMAGE: args.image});
+  images.forEach(function(imageName, index, images){
+    if (imageName.indexOf(':') < 0) {
+        images[index] = imageName + ':latest';
+    }
+  });
 
-  _.forEach(filteredTable, function(row) {
-    runCommandOnContainer(row['CONTAINER ID'], yargsToArgs(args));
+  var filteredTable = _.filter(psTable, function(image){
+    return images.indexOf(image.IMAGE) > -1;
+  });
+
+  _.forEach(filteredTable, function(container, index) {
+    var colorIndex = (index > availableColors.length - 1 ) ? index % availableColors.length : index;
+    runCommandOnContainer(container, yargsToArgs(args), availableColors[colorIndex]);
   });
 };

--- a/lib/commands/runDockerCommand.js
+++ b/lib/commands/runDockerCommand.js
@@ -1,20 +1,26 @@
 'use strict';
 
 var child = require('child_process');
+var colors = require('colors/safe');
 
-function runCommandOnContainer(containerId, commandArguments) {
+function runCommandOnContainer(container, commandArguments, color) {
+  var containerId = container['CONTAINER ID'];
+  var imageName = container['IMAGE']
   commandArguments.push(containerId);
-
   console.log('running ' + commandArguments.join(' ') + ' on container ' + containerId);
-
   var command = child.spawn('docker', commandArguments);
 
   command.stdout.on('data', function(chunk) {
-    console.log(chunk.toString());
+    var lines = chunk.toString().split('\n');
+
+    lines.forEach(function(line){
+       console.log(colors[color]('[' + imageName + ' - [' + containerId + ']: ') + line);
+    });
+
   });
 
   command.stderr.on('data', function(chunk) {
-    console.log(chunk.toString());
+    console.log(colors[color](chunk.toString()));
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/namshi/node-dock",
   "dependencies": {
+    "colors": "^1.1.2",
     "lodash": "^2.4.1",
     "node-shell-parser": "^0.1.0",
     "yargs": "^1.3.1"


### PR DESCRIPTION
against multiple images

You can now for example run `dock logs -f image1,image2,image3`, very handy
Every log lines has the image and container identifier, so it's easier to
distinguish the image logs
